### PR TITLE
✨ add static site baseline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy static site to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Berlin Trash Classifier
+
+A static GitHub Pages web app for helping Berlin expats learn proper trash classification through a quiz-first experience.
+
+## Current status
+
+This repository currently contains the planning baseline and the first implementation scaffold for:
+- a static site structure
+- Urban Alchemist design tokens and typography setup
+- landing, quiz, and cards page shells
+- JavaScript module entry points for future quiz/card logic
+
+## Local development
+
+Because this is a static site, use a simple local web server instead of opening files directly.
+
+### Python
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open:
+
+```text
+http://localhost:8000
+```
+
+## GitHub Pages
+
+This project is designed to be served as a static site.
+
+For GitHub Pages:
+- publish from GitHub Actions
+- keep all runtime behavior client-side
+- store content in static data files
+- avoid any server-side dependencies
+
+A workflow is included at `.github/workflows/pages.yml`.
+
+## Structure
+
+```text
+index.html
+cards/
+  index.html
+  item.html
+assets/
+  css/
+    tokens.css
+    base.css
+    components.css
+    pages.css
+  js/
+    app.js
+    quiz.js
+    cards.js
+    storage.js
+    data-loader.js
+  data/
+    disposal-items.json
+```

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,0 +1,54 @@
+* {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #fffaf8 0%, var(--color-surface) 55%);
+  color: var(--color-on-surface);
+  font-family: var(--font-body);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+a {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  cursor: pointer;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h1,
+h2,
+h3,
+.eyebrow,
+.topbar-title,
+.button,
+.badge,
+.answer-tile,
+.score-pill {
+  font-family: var(--font-display);
+}

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1,0 +1,180 @@
+.page-shell {
+  width: min(100%, 76rem);
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4) var(--space-12);
+}
+
+.topbar,
+.quiz-chrome,
+.progress-meta,
+.hero-actions,
+.cards-grid,
+.answer-grid {
+  display: flex;
+}
+
+.topbar,
+.quiz-chrome,
+.progress-meta {
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.topbar-title,
+.quiz-title,
+h1,
+h2 {
+  letter-spacing: -0.03em;
+}
+
+.topbar-title {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(47, 47, 47, 0.72);
+}
+
+.surface-panel {
+  background: var(--color-surface-container);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+}
+
+.surface-panel--soft {
+  background: var(--color-surface-container-low);
+}
+
+.surface-panel--nested {
+  background: var(--color-surface-container-lowest);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 0.9rem 1.4rem;
+  border-radius: var(--radius-full);
+  font-weight: 700;
+}
+
+.button--primary {
+  background: var(--button-gradient);
+  color: #fff;
+}
+
+.button--secondary {
+  background: var(--color-surface-container-highest);
+}
+
+.button--tertiary {
+  padding-inline: 0;
+  color: var(--color-primary);
+}
+
+.icon-button,
+.score-pill,
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+}
+
+.icon-button {
+  width: 2.75rem;
+  height: 2.75rem;
+  background: var(--glass-surface);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-ambient);
+}
+
+.score-pill {
+  padding: 0.7rem 1rem;
+  background: var(--glass-surface);
+  backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-ambient);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.score-pill--ghost {
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.progress-track {
+  width: 100%;
+  height: 1.25rem;
+  border-radius: var(--radius-full);
+  background: rgba(47, 47, 47, 0.08);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--button-gradient);
+}
+
+.item-card {
+  display: grid;
+  place-items: center;
+  gap: var(--space-3);
+  min-height: 16rem;
+  padding: var(--space-8);
+  background: var(--color-surface-container-lowest);
+  border-radius: 2.25rem;
+}
+
+.item-emoji {
+  font-size: clamp(4rem, 12vw, 7rem);
+}
+
+.item-caption,
+.lead {
+  line-height: 1.6;
+}
+
+.answer-grid {
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.answer-tile {
+  flex: 1 1 calc(50% - var(--space-4));
+  min-width: 10rem;
+  min-height: 5.5rem;
+  padding: var(--space-6);
+  border-radius: 1.75rem;
+  font-weight: 800;
+  box-shadow: var(--shadow-ambient);
+  color: var(--color-on-surface);
+}
+
+.answer-tile--paper { background: var(--color-paper); }
+.answer-tile--packaging { background: var(--color-packaging); }
+.answer-tile--bio { background: var(--color-bio); }
+.answer-tile--residual { background: var(--color-residual); }
+
+.badge {
+  width: fit-content;
+  padding: 0.55rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.badge--paper { background: var(--color-paper); }
+.badge--packaging { background: var(--color-packaging); }
+.badge--bio { background: var(--color-bio); }
+.badge--residual { background: var(--color-residual); }

--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -1,0 +1,69 @@
+.hero {
+  display: grid;
+  gap: var(--space-8);
+  margin-top: var(--space-8);
+}
+
+.hero-copy,
+.quiz-preview,
+.detail-layout,
+.mini-card {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.hero-copy h1,
+.cards-layout h1,
+.detail-layout h1 {
+  font-size: clamp(2.5rem, 7vw, 4.75rem);
+}
+
+.quiz-title {
+  text-align: center;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+}
+
+.cards-layout,
+.detail-layout {
+  margin-top: var(--space-8);
+}
+
+.cards-grid {
+  flex-wrap: wrap;
+  gap: var(--space-6);
+  margin-top: var(--space-8);
+}
+
+.mini-card {
+  flex: 1 1 18rem;
+}
+
+.detail-note {
+  font-size: 1.05rem;
+}
+
+@media (min-width: 56rem) {
+  .hero {
+    grid-template-columns: 1.05fr 0.95fr;
+    align-items: start;
+  }
+}
+
+@media (max-width: 40rem) {
+  .page-shell {
+    padding-inline: var(--space-3);
+  }
+
+  .surface-panel {
+    padding: var(--space-6);
+  }
+
+  .answer-grid {
+    gap: var(--space-3);
+  }
+
+  .answer-tile {
+    min-width: calc(50% - var(--space-3));
+    min-height: 4.75rem;
+  }
+}

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -1,0 +1,41 @@
+:root {
+  --color-surface: #f9f6f5;
+  --color-surface-bright: #fffdfc;
+  --color-surface-container: #eae8e7;
+  --color-surface-container-low: #f1efee;
+  --color-surface-container-lowest: #ffffff;
+  --color-surface-container-highest: #ddd8d6;
+  --color-on-surface: #2f2f2f;
+  --color-outline-ghost: rgba(47, 47, 47, 0.15);
+
+  --color-primary: #9c3f00;
+  --color-primary-container: #ff7a2f;
+  --color-secondary: #5b8a3c;
+  --color-secondary-container: #d9ebc8;
+  --color-tertiary: #d89a00;
+  --color-tertiary-container: #ffe29b;
+  --color-paper: #dbe8ff;
+  --color-packaging: #ffe6a8;
+  --color-bio: #e1c7a8;
+  --color-residual: #d9d4d2;
+
+  --font-display: "Plus Jakarta Sans", system-ui, sans-serif;
+  --font-body: "Be Vietnam Pro", system-ui, sans-serif;
+
+  --radius-sm: 1rem;
+  --radius-md: 1.5rem;
+  --radius-lg: 2rem;
+  --radius-full: 999px;
+
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  --shadow-ambient: 0 20px 40px rgba(47, 47, 47, 0.06);
+  --glass-surface: rgba(249, 246, 245, 0.78);
+  --button-gradient: linear-gradient(135deg, var(--color-primary), var(--color-primary-container));
+}

--- a/assets/data/disposal-items.json
+++ b/assets/data/disposal-items.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "greasy-pizza-box",
+    "name_en": "Greasy pizza box",
+    "question_prompt_en": "Where should this go?",
+    "primary_outcome": "residual",
+    "explanation_en": "If the box is greasy or contaminated with food, it usually belongs in residual waste instead of paper."
+  },
+  {
+    "slug": "yogurt-cup",
+    "name_en": "Yogurt cup",
+    "question_prompt_en": "Which bin fits this packaging item?",
+    "primary_outcome": "packaging",
+    "explanation_en": "Packaging like a cleaned yogurt cup typically belongs in the packaging stream."
+  }
+]

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,13 @@
+import { loadDisposalItems } from "./data-loader.js";
+import { readProgress } from "./storage.js";
+import { createQuizState } from "./quiz.js";
+
+async function init() {
+  const items = await loadDisposalItems();
+  const progress = readProgress();
+  createQuizState(items, progress);
+}
+
+init().catch((error) => {
+  console.error("Failed to initialize app shell", error);
+});

--- a/assets/js/cards.js
+++ b/assets/js/cards.js
@@ -1,0 +1,5 @@
+import { loadDisposalItems } from "./data-loader.js";
+
+loadDisposalItems().catch((error) => {
+  console.error("Failed to load card data", error);
+});

--- a/assets/js/data-loader.js
+++ b/assets/js/data-loader.js
@@ -1,0 +1,10 @@
+export async function loadDisposalItems() {
+  const dataUrl = new URL("../data/disposal-items.json", import.meta.url);
+  const response = await fetch(dataUrl);
+
+  if (!response.ok) {
+    throw new Error(`Unable to load disposal items: ${response.status}`);
+  }
+
+  return response.json();
+}

--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -1,0 +1,7 @@
+export function createQuizState(items, progress) {
+  return {
+    items,
+    progress,
+    status: "preview"
+  };
+}

--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -1,0 +1,10 @@
+const STORAGE_KEY = "berlin-trash-classifier-progress";
+
+export function readProgress() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : { roundsCompleted: 0, correctAnswers: 0 };
+  } catch {
+    return { roundsCompleted: 0, correctAnswers: 0 };
+  }
+}

--- a/cards/index.html
+++ b/cards/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cards · Berlin Trash Classifier</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;600&family=Plus+Jakarta+Sans:wght@500;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/tokens.css" />
+    <link rel="stylesheet" href="../assets/css/base.css" />
+    <link rel="stylesheet" href="../assets/css/components.css" />
+    <link rel="stylesheet" href="../assets/css/pages.css" />
+  </head>
+  <body>
+    <div class="page-shell page-shell--cards">
+      <header class="topbar">
+        <a class="icon-button" href="../index.html" aria-label="Back to home">←</a>
+        <span class="topbar-title">Cards</span>
+        <span class="score-pill score-pill--ghost">Preview</span>
+      </header>
+
+      <main class="cards-layout">
+        <section class="surface-panel surface-panel--soft">
+          <p class="eyebrow">Reference mode</p>
+          <h1>Browse disposal cards</h1>
+          <p class="lead">This is the future browse-first companion view for the quiz experience.</p>
+        </section>
+
+        <section class="cards-grid">
+          <article class="mini-card surface-panel">
+            <span class="badge badge--paper">Paper</span>
+            <h2>Pizza box</h2>
+            <p>Check contamination first before choosing the correct disposal path.</p>
+            <a class="button button--tertiary" href="item.html">Open card</a>
+          </article>
+
+          <article class="mini-card surface-panel">
+            <span class="badge badge--packaging">Packaging</span>
+            <h2>Yogurt cup</h2>
+            <p>Packaging items will later be backed by the curated static data file.</p>
+            <a class="button button--tertiary" href="item.html">Open card</a>
+          </article>
+        </section>
+      </main>
+    </div>
+
+    <script type="module" src="../assets/js/cards.js"></script>
+  </body>
+</html>

--- a/cards/item.html
+++ b/cards/item.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Card · Berlin Trash Classifier</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;600&family=Plus+Jakarta+Sans:wght@500;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/tokens.css" />
+    <link rel="stylesheet" href="../assets/css/base.css" />
+    <link rel="stylesheet" href="../assets/css/components.css" />
+    <link rel="stylesheet" href="../assets/css/pages.css" />
+  </head>
+  <body>
+    <div class="page-shell page-shell--detail">
+      <header class="topbar">
+        <a class="icon-button" href="index.html" aria-label="Back to cards">←</a>
+        <span class="topbar-title">Card detail</span>
+        <span class="score-pill score-pill--ghost">Preview</span>
+      </header>
+
+      <main class="detail-layout surface-panel">
+        <span class="badge badge--residual">Residual</span>
+        <h1>Greasy pizza box</h1>
+        <p class="lead">
+          This preview card shows the intended tonal layering and typography treatment for detailed
+          disposal guidance.
+        </p>
+        <div class="detail-note surface-panel surface-panel--nested">
+          If the box is greasy or contaminated with food, it will usually belong in residual waste
+          rather than paper.
+        </div>
+      </main>
+    </div>
+
+    <script type="module" src="../assets/js/cards.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Berlin Trash Classifier</title>
+    <meta
+      name="description"
+      content="Learn how to sort waste correctly in Berlin through a quiz-first educational experience."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;600&family=Plus+Jakarta+Sans:wght@500;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/tokens.css" />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/pages.css" />
+  </head>
+  <body>
+    <div class="page-shell page-shell--home">
+      <header class="topbar topbar--home">
+        <span class="eyebrow">The Urban Alchemist</span>
+        <span class="score-pill score-pill--ghost">No account needed</span>
+      </header>
+
+      <main class="hero hero--home">
+        <section class="hero-copy surface-panel surface-panel--soft">
+          <p class="eyebrow">Berlin trash guide</p>
+          <h1>Sort waste like a local.</h1>
+          <p class="lead">
+            A premium, quiz-first learning experience for Berlin expats who want to understand paper,
+            packaging, bio waste, residual waste, and the tricky edge cases in between.
+          </p>
+          <div class="hero-actions">
+            <a class="button button--primary" href="#quiz-preview">Start quiz</a>
+            <a class="button button--secondary" href="cards/index.html">Browse cards</a>
+          </div>
+        </section>
+
+        <section id="quiz-preview" class="quiz-preview surface-panel">
+          <div class="quiz-chrome">
+            <a class="icon-button" href="/" aria-label="Go back">←</a>
+            <span class="topbar-title">TrashQuiz</span>
+            <span class="score-pill">+0 pts</span>
+          </div>
+
+          <div class="progress-meta">
+            <span>1 / 5</span>
+            <span>Warm-up round</span>
+          </div>
+          <div class="progress-track" aria-hidden="true">
+            <div class="progress-fill" style="width: 20%"></div>
+          </div>
+
+          <h2 class="quiz-title">Where should this go?</h2>
+
+          <div class="item-stage">
+            <div class="item-card">
+              <div class="item-emoji" aria-hidden="true">🍕</div>
+              <p class="item-caption">Greasy pizza box</p>
+            </div>
+          </div>
+
+          <div class="answer-grid">
+            <button class="answer-tile answer-tile--paper" type="button">Paper</button>
+            <button class="answer-tile answer-tile--packaging" type="button">Packaging</button>
+            <button class="answer-tile answer-tile--bio" type="button">Bio</button>
+            <button class="answer-tile answer-tile--residual" type="button">Residual</button>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script type="module" src="assets/js/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## What
- add the initial static site scaffold for the Berlin Trash Classifier
- add Urban Alchemist design token and page shell CSS files
- add placeholder landing/cards pages plus JS/data entry points
- add README local setup notes and a GitHub Pages workflow

## Why
This establishes the lowest-risk baseline for the project so later issues can layer in content, quiz logic, and the reference UI without backend complexity.

## How
- created static HTML entry points for home and cards views
- added token/base/component/page CSS structure for the design system
- added minimal JS modules and a starter static data file
- configured a Pages deployment workflow and documented local static serving

Closes #1

## Validation
- `node --check assets/js/app.js`
- `node --check assets/js/quiz.js`
- `node --check assets/js/cards.js`
- `node --check assets/js/storage.js`
- `node --check assets/js/data-loader.js`