### PR TITLE
✨ add browse learning cards

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -162,10 +162,15 @@ h2 {
   color: var(--color-on-surface);
 }
 
-.answer-tile--paper { background: var(--color-paper); }
-.answer-tile--packaging { background: var(--color-packaging); }
-.answer-tile--bio { background: var(--color-bio); }
-.answer-tile--residual { background: var(--color-residual); }
+.answer-tile--paper,
+.badge--paper { background: var(--color-paper); }
+.answer-tile--packaging,
+.badge--packaging { background: var(--color-packaging); }
+.answer-tile--bio,
+.badge--bio { background: var(--color-bio); }
+.answer-tile--residual,
+.badge--residual { background: var(--color-residual); }
+.badge--special { background: var(--color-tertiary-container); }
 
 .badge {
   width: fit-content;
@@ -174,7 +179,7 @@ h2 {
   font-weight: 700;
 }
 
-.badge--paper { background: var(--color-paper); }
-.badge--packaging { background: var(--color-packaging); }
-.badge--bio { background: var(--color-bio); }
-.badge--residual { background: var(--color-residual); }
+.notes-stack {
+  display: grid;
+  gap: var(--space-4);
+}

--- a/assets/js/cards.js
+++ b/assets/js/cards.js
@@ -1,5 +1,96 @@
-import { loadDisposalItems } from "./data-loader.js";
+import { loadCatalog } from "./data-loader.js";
 
-loadDisposalItems().catch((error) => {
-  console.error("Failed to load card data", error);
+const BADGE_CLASS_BY_OUTCOME = {
+  paper: "badge--paper",
+  packaging: "badge--packaging",
+  bio: "badge--bio",
+  residual: "badge--residual",
+  special: "badge--special"
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderCardsIndex(catalog) {
+  const container = document.querySelector("#cards-grid");
+  if (!container) return;
+
+  const outcomeByKey = Object.fromEntries(catalog.outcomes.map((outcome) => [outcome.key, outcome]));
+  const cards = catalog.items
+    .filter((item) => item.active)
+    .map((item) => {
+      const outcome = outcomeByKey[item.primary_outcome];
+      const badgeClass = BADGE_CLASS_BY_OUTCOME[item.primary_outcome] || "badge--residual";
+
+      return `
+        <article class="mini-card surface-panel">
+          <span class="badge ${badgeClass}">${escapeHtml(outcome?.label_en || "Unknown")}</span>
+          <h2>${escapeHtml(item.name_en)}</h2>
+          <p>${escapeHtml(item.explanation_en)}</p>
+          <a class="button button--tertiary" href="item.html?slug=${encodeURIComponent(item.slug)}">Open card</a>
+        </article>
+      `;
+    })
+    .join("");
+
+  container.innerHTML = cards;
+}
+
+function renderCardDetail(catalog) {
+  const container = document.querySelector("#card-detail");
+  if (!container) return;
+
+  const params = new URLSearchParams(window.location.search);
+  const requestedSlug = params.get("slug");
+  const item = catalog.items.find((entry) => entry.slug === requestedSlug) || catalog.items[0];
+  const outcome = catalog.outcomes.find((entry) => entry.key === item.primary_outcome);
+  const badgeClass = BADGE_CLASS_BY_OUTCOME[item.primary_outcome] || "badge--residual";
+  const notes = item.rule_notes?.length
+    ? `<div class="notes-stack">${item.rule_notes
+        .map(
+          (note) => `
+            <div class="detail-note surface-panel surface-panel--nested">
+              <strong>${escapeHtml(note.title_en)}</strong>
+              <p>${escapeHtml(note.body_en)}</p>
+            </div>
+          `
+        )
+        .join("")}</div>`
+    : "";
+
+  container.innerHTML = `
+    <span class="badge ${badgeClass}">${escapeHtml(outcome?.label_en || "Unknown")}</span>
+    <h1>${escapeHtml(item.name_en)}</h1>
+    <p class="lead">${escapeHtml(item.explanation_en)}</p>
+    <div class="detail-note surface-panel surface-panel--nested">
+      <strong>Why</strong>
+      <p>${escapeHtml(outcome?.short_description_en || "")}</p>
+    </div>
+    ${notes}
+    <a class="button button--tertiary" href="index.html">← Back to all cards</a>
+  `;
+}
+
+async function init() {
+  const page = document.body.dataset.page;
+  const catalog = await loadCatalog();
+
+  if (page === "cards-index") {
+    renderCardsIndex(catalog);
+    return;
+  }
+
+  if (page === "card-detail") {
+    renderCardDetail(catalog);
+  }
+}
+
+init().catch((error) => {
+  console.error("Failed to render card views", error);
 });

--- a/cards/index.html
+++ b/cards/index.html
@@ -15,36 +15,24 @@
     <link rel="stylesheet" href="../assets/css/components.css" />
     <link rel="stylesheet" href="../assets/css/pages.css" />
   </head>
-  <body>
+  <body data-page="cards-index">
     <div class="page-shell page-shell--cards">
       <header class="topbar">
         <a class="icon-button" href="../index.html" aria-label="Back to home">←</a>
         <span class="topbar-title">Cards</span>
-        <span class="score-pill score-pill--ghost">Preview</span>
+        <span class="score-pill score-pill--ghost">Browse mode</span>
       </header>
 
       <main class="cards-layout">
         <section class="surface-panel surface-panel--soft">
           <p class="eyebrow">Reference mode</p>
           <h1>Browse disposal cards</h1>
-          <p class="lead">This is the future browse-first companion view for the quiz experience.</p>
+          <p class="lead">
+            Explore common Berlin disposal cases in plain English before or after taking a quiz.
+          </p>
         </section>
 
-        <section class="cards-grid">
-          <article class="mini-card surface-panel">
-            <span class="badge badge--paper">Paper</span>
-            <h2>Pizza box</h2>
-            <p>Check contamination first before choosing the correct disposal path.</p>
-            <a class="button button--tertiary" href="item.html">Open card</a>
-          </article>
-
-          <article class="mini-card surface-panel">
-            <span class="badge badge--packaging">Packaging</span>
-            <h2>Yogurt cup</h2>
-            <p>Packaging items will later be backed by the curated static data file.</p>
-            <a class="button button--tertiary" href="item.html">Open card</a>
-          </article>
-        </section>
+        <section id="cards-grid" class="cards-grid" aria-live="polite"></section>
       </main>
     </div>
 

--- a/cards/item.html
+++ b/cards/item.html
@@ -15,26 +15,15 @@
     <link rel="stylesheet" href="../assets/css/components.css" />
     <link rel="stylesheet" href="../assets/css/pages.css" />
   </head>
-  <body>
+  <body data-page="card-detail">
     <div class="page-shell page-shell--detail">
       <header class="topbar">
         <a class="icon-button" href="index.html" aria-label="Back to cards">←</a>
         <span class="topbar-title">Card detail</span>
-        <span class="score-pill score-pill--ghost">Preview</span>
+        <span class="score-pill score-pill--ghost">Data-backed</span>
       </header>
 
-      <main class="detail-layout surface-panel">
-        <span class="badge badge--residual">Residual</span>
-        <h1>Greasy pizza box</h1>
-        <p class="lead">
-          This preview card shows the intended tonal layering and typography treatment for detailed
-          disposal guidance.
-        </p>
-        <div class="detail-note surface-panel surface-panel--nested">
-          If the box is greasy or contaminated with food, it will usually belong in residual waste
-          rather than paper.
-        </div>
-      </main>
+      <main id="card-detail" class="detail-layout surface-panel" aria-live="polite"></main>
     </div>
 
     <script type="module" src="../assets/js/cards.js"></script>


### PR DESCRIPTION
## What
- connect the cards pages to the static disposal dataset
- render a real browseable cards index from active items
- render a data-backed card detail view with outcome info and rule notes
- extend badge styling to cover special-disposal items

## Why
Issue #5 calls for a browse-first learning mode backed by the repo data model. The existing cards pages were still placeholders and did not reflect the seeded catalog.

## How
- updated `cards/index.html` to host a dynamic cards grid
- updated `cards/item.html` to host a dynamic detail view
- implemented dataset-driven rendering in `assets/js/cards.js`
- added special badge styling and notes-stack support in `assets/css/components.css`

Closes #5

## Validation
- `node --check assets/js/cards.js`
- Python sanity check to confirm every item references a valid outcome