### PR TITLE
✨ add client-side quiz flow

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -183,3 +183,22 @@ h2 {
   display: grid;
   gap: var(--space-4);
 }
+
+.feedback-panel {
+  display: grid;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
+  background: var(--glass-surface);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-ambient);
+}
+
+.feedback-panel--correct {
+  background: rgba(217, 235, 200, 0.9);
+}
+
+.feedback-panel--wrong {
+  background: rgba(255, 230, 168, 0.9);
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,11 +1,126 @@
-import { loadDisposalItems } from "./data-loader.js";
-import { readProgress } from "./storage.js";
-import { createQuizState } from "./quiz.js";
+import { loadCatalog } from "./data-loader.js";
+import { readProgress, writeProgress } from "./storage.js";
+import {
+  advanceQuiz,
+  createQuizState,
+  getAnswerOptions,
+  getCurrentItem,
+  getProgressPercent,
+  submitAnswer
+} from "./quiz.js";
+
+const ANSWER_TILE_CLASS = {
+  paper: "answer-tile--paper",
+  packaging: "answer-tile--packaging",
+  bio: "answer-tile--bio",
+  residual: "answer-tile--residual"
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function updateSummary(state) {
+  document.querySelector("#progress-summary").textContent = `${state.progress.roundsCompleted} rounds · ${state.progress.correctAnswers} correct`;
+  document.querySelector("#score-pill").textContent = `+${state.roundCorrect * 10} pts`;
+}
+
+function renderCompleteState(state) {
+  document.querySelector("#question-counter").textContent = `${state.items.length} / ${state.items.length}`;
+  document.querySelector("#round-label").textContent = "Round complete";
+  document.querySelector("#progress-fill").style.width = "100%";
+  document.querySelector("#quiz-title").textContent = `Round complete — ${state.roundCorrect}/${state.items.length}`;
+  document.querySelector("#item-caption").textContent = "Nice. You can replay by refreshing or jump into the next implementation issue.";
+  document.querySelector("#answer-grid").innerHTML = '<a class="button button--primary" href="#quiz-preview">Great job</a>';
+
+  const panel = document.querySelector("#feedback-panel");
+  panel.hidden = false;
+  panel.className = "feedback-panel feedback-panel--correct";
+  panel.innerHTML = `<strong>Score</strong><p>You earned ${state.roundCorrect * 10} points this round.</p>`;
+}
+
+function renderQuestion(state, catalog) {
+  if (state.status === "complete") {
+    renderCompleteState(state);
+    return;
+  }
+
+  const item = getCurrentItem(state);
+  if (!item) return;
+
+  const currentNumber = state.currentIndex + 1;
+  document.querySelector("#question-counter").textContent = `${currentNumber} / ${state.items.length}`;
+  document.querySelector("#round-label").textContent = state.answered ? "Answer reviewed" : "Choose one answer";
+  document.querySelector("#progress-fill").style.width = `${getProgressPercent(state)}%`;
+  document.querySelector("#quiz-title").textContent = item.question_prompt_en;
+  document.querySelector("#item-caption").textContent = item.name_en;
+  updateSummary(state);
+
+  const answerGrid = document.querySelector("#answer-grid");
+  const feedbackPanel = document.querySelector("#feedback-panel");
+  const options = getAnswerOptions(catalog.outcomes);
+
+  if (!state.answered) {
+    answerGrid.innerHTML = options
+      .map(
+        (option) => `
+          <button class="answer-tile ${ANSWER_TILE_CLASS[option.key] ?? ""}" type="button" data-outcome-key="${option.key}">
+            ${escapeHtml(option.label_en)}
+          </button>
+        `
+      )
+      .join("");
+
+    answerGrid.querySelectorAll("button").forEach((button) => {
+      button.addEventListener("click", () => {
+        submitAnswer(state, button.dataset.outcomeKey);
+        writeProgress(state.progress);
+        renderQuestion(state, catalog);
+      });
+    });
+
+    feedbackPanel.hidden = true;
+    feedbackPanel.innerHTML = "";
+    return;
+  }
+
+  const outcome = catalog.outcomes.find((entry) => entry.key === item.primary_outcome);
+  const correct = item.primary_outcome === state.selectedOutcome;
+
+  answerGrid.innerHTML = '<button id="next-question" class="button button--primary" type="button">Next</button>';
+  document.querySelector("#next-question").addEventListener("click", () => {
+    advanceQuiz(state);
+    writeProgress(state.progress);
+    renderQuestion(state, catalog);
+  });
+
+  feedbackPanel.hidden = false;
+  feedbackPanel.className = `feedback-panel ${correct ? "feedback-panel--correct" : "feedback-panel--wrong"}`;
+  feedbackPanel.innerHTML = `
+    <strong>${correct ? "Correct!" : "Not quite"}</strong>
+    <p>${escapeHtml(item.explanation_en)}</p>
+    <p><span class="badge ${correct ? ANSWER_TILE_CLASS[item.primary_outcome]?.replace("answer-tile", "badge") || "badge--residual" : "badge--residual"}">${escapeHtml(outcome?.label_en || item.primary_outcome)}</span></p>
+  `;
+}
 
 async function init() {
-  const items = await loadDisposalItems();
+  const catalog = await loadCatalog();
   const progress = readProgress();
-  createQuizState(items, progress);
+  const state = createQuizState(catalog.items, progress);
+
+  if (state.status === "empty") {
+    document.querySelector("#quiz-title").textContent = "No quiz items available yet";
+    document.querySelector("#item-caption").textContent = "Add more active disposal items to start the quiz.";
+    document.querySelector("#answer-grid").innerHTML = "";
+    return;
+  }
+
+  renderQuestion(state, catalog);
 }
 
 init().catch((error) => {

--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -1,7 +1,74 @@
-export function createQuizState(items, progress) {
+const ROUND_SIZE = 5;
+const ANSWER_KEYS = ["paper", "packaging", "bio", "residual"];
+
+function createInitialProgress(progress) {
   return {
-    items,
-    progress,
-    status: "preview"
+    roundsCompleted: progress?.roundsCompleted ?? 0,
+    correctAnswers: progress?.correctAnswers ?? 0,
+    questionsAnswered: progress?.questionsAnswered ?? 0
   };
+}
+
+function selectRoundItems(items) {
+  const eligible = items.filter((item) => item.active && ANSWER_KEYS.includes(item.primary_outcome));
+  return eligible.slice(0, Math.min(ROUND_SIZE, eligible.length));
+}
+
+export function createQuizState(items, progress) {
+  const roundItems = selectRoundItems(items);
+
+  return {
+    items: roundItems,
+    progress: createInitialProgress(progress),
+    currentIndex: 0,
+    roundCorrect: 0,
+    answered: false,
+    selectedOutcome: null,
+    status: roundItems.length ? "ready" : "empty"
+  };
+}
+
+export function getAnswerOptions(outcomes) {
+  return ANSWER_KEYS.map((key) => outcomes.find((outcome) => outcome.key === key)).filter(Boolean);
+}
+
+export function getCurrentItem(state) {
+  return state.items[state.currentIndex] ?? null;
+}
+
+export function getProgressPercent(state) {
+  if (!state.items.length) return 0;
+  return ((state.currentIndex + 1) / state.items.length) * 100;
+}
+
+export function submitAnswer(state, outcomeKey) {
+  const item = getCurrentItem(state);
+  if (!item || state.answered) return state;
+
+  state.answered = true;
+  state.selectedOutcome = outcomeKey;
+  state.progress.questionsAnswered += 1;
+
+  if (item.primary_outcome === outcomeKey) {
+    state.roundCorrect += 1;
+    state.progress.correctAnswers += 1;
+  }
+
+  return state;
+}
+
+export function advanceQuiz(state) {
+  if (!state.answered) return state;
+
+  const nextIndex = state.currentIndex + 1;
+  if (nextIndex >= state.items.length) {
+    state.status = "complete";
+    state.progress.roundsCompleted += 1;
+    return state;
+  }
+
+  state.currentIndex = nextIndex;
+  state.answered = false;
+  state.selectedOutcome = null;
+  return state;
 }

--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -1,10 +1,24 @@
 const STORAGE_KEY = "berlin-trash-classifier-progress";
 
+const DEFAULT_PROGRESS = {
+  roundsCompleted: 0,
+  correctAnswers: 0,
+  questionsAnswered: 0
+};
+
 export function readProgress() {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : { roundsCompleted: 0, correctAnswers: 0 };
+    return raw ? { ...DEFAULT_PROGRESS, ...JSON.parse(raw) } : { ...DEFAULT_PROGRESS };
   } catch {
-    return { roundsCompleted: 0, correctAnswers: 0 };
+    return { ...DEFAULT_PROGRESS };
+  }
+}
+
+export function writeProgress(progress) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+  } catch {
+    // Ignore storage failures for MVP scaffold.
   }
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <div class="page-shell page-shell--home">
       <header class="topbar topbar--home">
         <span class="eyebrow">The Urban Alchemist</span>
-        <span class="score-pill score-pill--ghost">No account needed</span>
+        <span id="progress-summary" class="score-pill score-pill--ghost">No account needed</span>
       </header>
 
       <main class="hero hero--home">
@@ -42,34 +42,30 @@
 
         <section id="quiz-preview" class="quiz-preview surface-panel">
           <div class="quiz-chrome">
-            <a class="icon-button" href="/" aria-label="Go back">←</a>
+            <a class="icon-button" href="./" aria-label="Go back">←</a>
             <span class="topbar-title">TrashQuiz</span>
-            <span class="score-pill">+0 pts</span>
+            <span id="score-pill" class="score-pill">+0 pts</span>
           </div>
 
           <div class="progress-meta">
-            <span>1 / 5</span>
-            <span>Warm-up round</span>
+            <span id="question-counter">1 / 5</span>
+            <span id="round-label">Warm-up round</span>
           </div>
           <div class="progress-track" aria-hidden="true">
-            <div class="progress-fill" style="width: 20%"></div>
+            <div id="progress-fill" class="progress-fill" style="width: 20%"></div>
           </div>
 
-          <h2 class="quiz-title">Where should this go?</h2>
+          <h2 id="quiz-title" class="quiz-title">Where should this go?</h2>
 
           <div class="item-stage">
             <div class="item-card">
-              <div class="item-emoji" aria-hidden="true">🍕</div>
-              <p class="item-caption">Greasy pizza box</p>
+              <div class="item-emoji" aria-hidden="true">🗑️</div>
+              <p id="item-caption" class="item-caption">Loading quiz item…</p>
             </div>
           </div>
 
-          <div class="answer-grid">
-            <button class="answer-tile answer-tile--paper" type="button">Paper</button>
-            <button class="answer-tile answer-tile--packaging" type="button">Packaging</button>
-            <button class="answer-tile answer-tile--bio" type="button">Bio</button>
-            <button class="answer-tile answer-tile--residual" type="button">Residual</button>
-          </div>
+          <div id="answer-grid" class="answer-grid"></div>
+          <div id="feedback-panel" class="feedback-panel" hidden></div>
         </section>
       </main>
     </div>

--- a/tests/quiz-logic/quiz.test.js
+++ b/tests/quiz-logic/quiz.test.js
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { advanceQuiz, createQuizState, submitAnswer } from "../../assets/js/quiz.js";
+
+const items = [
+  { slug: "clean-cardboard-box", active: true, primary_outcome: "paper" },
+  { slug: "yogurt-cup", active: true, primary_outcome: "packaging" },
+  { slug: "banana-peel", active: true, primary_outcome: "bio" },
+  { slug: "used-tissue", active: true, primary_outcome: "residual" },
+  { slug: "newspaper", active: true, primary_outcome: "paper" }
+];
+
+const initial = createQuizState(items, { roundsCompleted: 0, correctAnswers: 0, questionsAnswered: 0 });
+assert.equal(initial.items.length, 5);
+assert.equal(initial.status, "ready");
+
+submitAnswer(initial, "paper");
+assert.equal(initial.answered, true);
+assert.equal(initial.roundCorrect, 1);
+assert.equal(initial.progress.correctAnswers, 1);
+
+advanceQuiz(initial);
+assert.equal(initial.currentIndex, 1);
+assert.equal(initial.answered, false);
+
+submitAnswer(initial, "paper");
+advanceQuiz(initial);
+submitAnswer(initial, "bio");
+advanceQuiz(initial);
+submitAnswer(initial, "residual");
+advanceQuiz(initial);
+submitAnswer(initial, "paper");
+advanceQuiz(initial);
+
+assert.equal(initial.status, "complete");
+assert.equal(initial.progress.roundsCompleted, 1);


### PR DESCRIPTION
## What
- turn the homepage quiz preview into a real client-side quiz round
- render one active dataset item at a time with tappable answer tiles
- track round progress, score, and lightweight local progress stats
- add a lightweight quiz logic test for the round flow

## Why
Issue #3 is the actual MVP interaction loop. The existing homepage only showed a static mock and did not let users answer questions or progress through a round.

## How
- implemented round state, answer submission, and advancement logic in `assets/js/quiz.js`
- wired the homepage quiz shell to the dataset and local storage in `assets/js/app.js`
- updated `index.html` to host dynamic quiz content and feedback
- added feedback panel styling in `assets/css/components.css`
- added a small Node-based quiz logic test in `tests/quiz-logic/quiz.test.js`

Closes #3

## Validation
- `node --check assets/js/app.js`
- `node --check assets/js/quiz.js`
- `node --check assets/js/storage.js`
- `node --check tests/quiz-logic/quiz.test.js`
- `node tests/quiz-logic/quiz.test.js`