### PR TITLE
✨ improve quiz UI

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -9,16 +9,26 @@
 .progress-meta,
 .hero-actions,
 .cards-grid,
-.answer-grid {
+.answer-grid,
+.quiz-topbar,
+.quiz-branding {
   display: flex;
 }
 
 .topbar,
 .quiz-chrome,
-.progress-meta {
+.progress-meta,
+.quiz-topbar {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
+}
+
+.quiz-branding {
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  text-align: center;
 }
 
 .topbar-title,
@@ -56,6 +66,10 @@ h2 {
 
 .surface-panel--nested {
   background: var(--color-surface-container-lowest);
+}
+
+.surface-panel--quiz {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7), var(--color-surface-container));
 }
 
 .button {
@@ -137,13 +151,32 @@ h2 {
   border-radius: 2.25rem;
 }
 
+.item-card--hero {
+  min-height: clamp(18rem, 46vw, 28rem);
+  width: min(100%, 28rem);
+  margin: 0 auto;
+  background: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(234,232,231,0.9));
+}
+
 .item-emoji {
   font-size: clamp(4rem, 12vw, 7rem);
 }
 
 .item-caption,
-.lead {
+.lead,
+.item-hint {
   line-height: 1.6;
+}
+
+.item-caption {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+
+.item-hint {
+  color: rgba(47, 47, 47, 0.68);
+  text-align: center;
 }
 
 .answer-grid {
@@ -151,15 +184,34 @@ h2 {
   gap: var(--space-4);
 }
 
+.answer-grid--quiz {
+  margin-top: var(--space-2);
+}
+
 .answer-tile {
   flex: 1 1 calc(50% - var(--space-4));
   min-width: 10rem;
-  min-height: 5.5rem;
+  min-height: 6.5rem;
   padding: var(--space-6);
   border-radius: 1.75rem;
   font-weight: 800;
   box-shadow: var(--shadow-ambient);
   color: var(--color-on-surface);
+  text-align: left;
+}
+
+.answer-tile__label {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+}
+
+.answer-tile__hint {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: rgba(47, 47, 47, 0.72);
 }
 
 .answer-tile--paper,

--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -7,20 +7,44 @@
 .hero-copy,
 .quiz-preview,
 .detail-layout,
-.mini-card {
+.mini-card,
+.quiz-layout,
+.quiz-progress-shell,
+.quiz-headline-block,
+.quiz-support {
   display: grid;
   gap: var(--space-6);
 }
 
 .hero-copy h1,
 .cards-layout h1,
-.detail-layout h1 {
-  font-size: clamp(2.5rem, 7vw, 4.75rem);
+.detail-layout h1,
+.quiz-support h2 {
+  font-size: clamp(2.2rem, 6vw, 4rem);
 }
 
 .quiz-title {
   text-align: center;
-  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-size: clamp(2.1rem, 5vw, 3.75rem);
+  max-width: 16ch;
+  margin: 0 auto;
+}
+
+.quiz-layout {
+  margin-top: var(--space-8);
+}
+
+.quiz-headline-block {
+  justify-items: center;
+}
+
+.item-stage--hero {
+  margin-top: var(--space-2);
+}
+
+.progress-meta--quiz {
+  font-family: var(--font-display);
+  font-weight: 700;
 }
 
 .cards-layout,
@@ -40,6 +64,13 @@
 
 .detail-note {
   font-size: 1.05rem;
+}
+
+@media (min-width: 64rem) {
+  .quiz-layout {
+    grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.75fr);
+    align-items: start;
+  }
 }
 
 @media (min-width: 56rem) {
@@ -64,6 +95,10 @@
 
   .answer-tile {
     min-width: calc(50% - var(--space-3));
-    min-height: 4.75rem;
+    min-height: 5.25rem;
+  }
+
+  .quiz-title {
+    font-size: 2rem;
   }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,14 @@ const ANSWER_TILE_CLASS = {
   residual: "answer-tile--residual"
 };
 
+const ITEM_EMOJI_BY_OUTCOME = {
+  paper: "📦",
+  packaging: "🥤",
+  bio: "🍌",
+  residual: "🧻",
+  special: "🔋"
+};
+
 function escapeHtml(value) {
   return String(value)
     .replaceAll("&", "&amp;")
@@ -25,9 +33,17 @@ function escapeHtml(value) {
     .replaceAll("'", "&#39;");
 }
 
+function getOutcomeBadgeClass(outcomeKey) {
+  return ANSWER_TILE_CLASS[outcomeKey]?.replace("answer-tile", "badge") || "badge--residual";
+}
+
+function getItemEmoji(item) {
+  return ITEM_EMOJI_BY_OUTCOME[item.primary_outcome] || "🗑️";
+}
+
 function updateSummary(state) {
   document.querySelector("#progress-summary").textContent = `${state.progress.roundsCompleted} rounds · ${state.progress.correctAnswers} correct`;
-  document.querySelector("#score-pill").textContent = `+${state.roundCorrect * 10} pts`;
+  document.querySelector("#score-pill").textContent = `Points ${state.roundCorrect * 10}`;
 }
 
 function renderCompleteState(state) {
@@ -35,7 +51,9 @@ function renderCompleteState(state) {
   document.querySelector("#round-label").textContent = "Round complete";
   document.querySelector("#progress-fill").style.width = "100%";
   document.querySelector("#quiz-title").textContent = `Round complete — ${state.roundCorrect}/${state.items.length}`;
-  document.querySelector("#item-caption").textContent = "Nice. You can replay by refreshing or jump into the next implementation issue.";
+  document.querySelector("#item-emoji").textContent = "🏁";
+  document.querySelector("#item-caption").textContent = "Nice. You can replay by refreshing or move on to the next issue.";
+  document.querySelector("#item-hint").textContent = "You just completed the current learning round.";
   document.querySelector("#answer-grid").innerHTML = '<a class="button button--primary" href="#quiz-preview">Great job</a>';
 
   const panel = document.querySelector("#feedback-panel");
@@ -54,11 +72,13 @@ function renderQuestion(state, catalog) {
   if (!item) return;
 
   const currentNumber = state.currentIndex + 1;
-  document.querySelector("#question-counter").textContent = `${currentNumber} / ${state.items.length}`;
-  document.querySelector("#round-label").textContent = state.answered ? "Answer reviewed" : "Choose one answer";
+  document.querySelector("#question-counter").textContent = `Question ${currentNumber} of ${state.items.length}`;
+  document.querySelector("#round-label").textContent = state.answered ? "Answer reviewed" : `${Math.round(getProgressPercent(state))}% complete`;
   document.querySelector("#progress-fill").style.width = `${getProgressPercent(state)}%`;
   document.querySelector("#quiz-title").textContent = item.question_prompt_en;
+  document.querySelector("#item-emoji").textContent = getItemEmoji(item);
   document.querySelector("#item-caption").textContent = item.name_en;
+  document.querySelector("#item-hint").textContent = item.source_note || "Choose the best Berlin disposal path.";
   updateSummary(state);
 
   const answerGrid = document.querySelector("#answer-grid");
@@ -70,7 +90,8 @@ function renderQuestion(state, catalog) {
       .map(
         (option) => `
           <button class="answer-tile ${ANSWER_TILE_CLASS[option.key] ?? ""}" type="button" data-outcome-key="${option.key}">
-            ${escapeHtml(option.label_en)}
+            <span class="answer-tile__label">${escapeHtml(option.label_en)}</span>
+            <span class="answer-tile__hint">${escapeHtml(option.short_description_en)}</span>
           </button>
         `
       )
@@ -92,7 +113,7 @@ function renderQuestion(state, catalog) {
   const outcome = catalog.outcomes.find((entry) => entry.key === item.primary_outcome);
   const correct = item.primary_outcome === state.selectedOutcome;
 
-  answerGrid.innerHTML = '<button id="next-question" class="button button--primary" type="button">Next</button>';
+  answerGrid.innerHTML = '<button id="next-question" class="button button--primary" type="button">Next question</button>';
   document.querySelector("#next-question").addEventListener("click", () => {
     advanceQuiz(state);
     writeProgress(state.progress);
@@ -104,7 +125,7 @@ function renderQuestion(state, catalog) {
   feedbackPanel.innerHTML = `
     <strong>${correct ? "Correct!" : "Not quite"}</strong>
     <p>${escapeHtml(item.explanation_en)}</p>
-    <p><span class="badge ${correct ? ANSWER_TILE_CLASS[item.primary_outcome]?.replace("answer-tile", "badge") || "badge--residual" : "badge--residual"}">${escapeHtml(outcome?.label_en || item.primary_outcome)}</span></p>
+    <p><span class="badge ${getOutcomeBadgeClass(item.primary_outcome)}">${escapeHtml(outcome?.label_en || item.primary_outcome)}</span></p>
   `;
 }
 
@@ -116,6 +137,7 @@ async function init() {
   if (state.status === "empty") {
     document.querySelector("#quiz-title").textContent = "No quiz items available yet";
     document.querySelector("#item-caption").textContent = "Add more active disposal items to start the quiz.";
+    document.querySelector("#item-hint").textContent = "The quiz shell is ready for more content.";
     document.querySelector("#answer-grid").innerHTML = "";
     return;
   }

--- a/index.html
+++ b/index.html
@@ -20,52 +20,56 @@
     <link rel="stylesheet" href="assets/css/pages.css" />
   </head>
   <body>
-    <div class="page-shell page-shell--home">
-      <header class="topbar topbar--home">
-        <span class="eyebrow">The Urban Alchemist</span>
-        <span id="progress-summary" class="score-pill score-pill--ghost">No account needed</span>
+    <div class="page-shell page-shell--quiz">
+      <header class="quiz-topbar">
+        <a class="icon-button" href="./" aria-label="Refresh quiz">←</a>
+        <div class="quiz-branding">
+          <span class="eyebrow">Berlin Sortiert</span>
+          <span class="topbar-title">Quiz mode</span>
+        </div>
+        <span id="score-pill" class="score-pill">+0 pts</span>
       </header>
 
-      <main class="hero hero--home">
-        <section class="hero-copy surface-panel surface-panel--soft">
-          <p class="eyebrow">Berlin trash guide</p>
-          <h1>Sort waste like a local.</h1>
-          <p class="lead">
-            A premium, quiz-first learning experience for Berlin expats who want to understand paper,
-            packaging, bio waste, residual waste, and the tricky edge cases in between.
-          </p>
-          <div class="hero-actions">
-            <a class="button button--primary" href="#quiz-preview">Start quiz</a>
-            <a class="button button--secondary" href="cards/index.html">Browse cards</a>
-          </div>
-        </section>
-
-        <section id="quiz-preview" class="quiz-preview surface-panel">
-          <div class="quiz-chrome">
-            <a class="icon-button" href="./" aria-label="Go back">←</a>
-            <span class="topbar-title">TrashQuiz</span>
-            <span id="score-pill" class="score-pill">+0 pts</span>
-          </div>
-
-          <div class="progress-meta">
-            <span id="question-counter">1 / 5</span>
-            <span id="round-label">Warm-up round</span>
-          </div>
-          <div class="progress-track" aria-hidden="true">
-            <div id="progress-fill" class="progress-fill" style="width: 20%"></div>
-          </div>
-
-          <h2 id="quiz-title" class="quiz-title">Where should this go?</h2>
-
-          <div class="item-stage">
-            <div class="item-card">
-              <div class="item-emoji" aria-hidden="true">🗑️</div>
-              <p id="item-caption" class="item-caption">Loading quiz item…</p>
+      <main class="quiz-layout">
+        <section id="quiz-preview" class="quiz-preview surface-panel surface-panel--quiz">
+          <div class="quiz-progress-shell">
+            <div class="progress-meta progress-meta--quiz">
+              <span id="question-counter">1 / 5</span>
+              <span id="round-label">Warm-up round</span>
+            </div>
+            <div class="progress-track" aria-hidden="true">
+              <div id="progress-fill" class="progress-fill" style="width: 20%"></div>
             </div>
           </div>
 
-          <div id="answer-grid" class="answer-grid"></div>
+          <div class="quiz-headline-block">
+            <span id="progress-summary" class="score-pill score-pill--ghost">No account needed</span>
+            <h1 id="quiz-title" class="quiz-title">Where should this go?</h1>
+          </div>
+
+          <div class="item-stage item-stage--hero">
+            <div class="item-card item-card--hero">
+              <div id="item-emoji" class="item-emoji" aria-hidden="true">🗑️</div>
+              <p id="item-caption" class="item-caption">Loading quiz item…</p>
+              <p id="item-hint" class="item-hint">Think like a Berlin local.</p>
+            </div>
+          </div>
+
+          <div id="answer-grid" class="answer-grid answer-grid--quiz"></div>
           <div id="feedback-panel" class="feedback-panel" hidden></div>
+        </section>
+
+        <section class="quiz-support surface-panel surface-panel--soft">
+          <p class="eyebrow">Urban Alchemist</p>
+          <h2>Learn the logic, not just the bin color.</h2>
+          <p class="lead">
+            This quiz is built for Berlin expats. Short explanations and tricky examples help you
+            understand why an item belongs in paper, packaging, bio, residual waste, or a special
+            collection path.
+          </p>
+          <div class="hero-actions">
+            <a class="button button--secondary" href="cards/index.html">Browse cards</a>
+          </div>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## What
- restyle the quiz screen to match the issue reference more closely
- promote the quiz into a dedicated hero-style layout
- improve progress chrome, item stage, answer tiles, and score presentation
- keep the existing quiz logic intact while making the UI feel more app-like

## Why
Issue #16 is specifically about bringing the quiz page closer to the supplied mock and attached HTML reference. The existing quiz flow worked, but the visual hierarchy still felt like a scaffold rather than the intended polished experience.

## How
- reshaped `index.html` into a more dedicated quiz-first layout
- updated `assets/css/components.css` and `assets/css/pages.css` for stronger quiz presentation
- enhanced `assets/js/app.js` to render richer tile copy, emoji/item chrome, and more reference-like progress/points text

Closes #16

## Validation
- `node --check assets/js/app.js`
- `node --check assets/js/quiz.js`
- `node --check assets/js/storage.js`