### PR TITLE
🐛 fix quiz visuals and round length

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,12 +16,31 @@ const ANSWER_TILE_CLASS = {
   residual: "answer-tile--residual"
 };
 
-const ITEM_EMOJI_BY_OUTCOME = {
-  paper: "📦",
-  packaging: "🥤",
-  bio: "🍌",
-  residual: "🧻",
-  special: "🔋"
+const ITEM_EMOJI_BY_SLUG = {
+  "greasy-pizza-box": "🍕",
+  "clean-cardboard-box": "📦",
+  newspaper: "📰",
+  "paper-egg-carton": "🥚",
+  "receipt-paper": "🧾",
+  "yogurt-cup": "🥛",
+  "plastic-bottle-no-deposit": "🧴",
+  "tin-can": "🥫",
+  "aluminum-foil-clean": "✨",
+  "drink-carton": "🧃",
+  "banana-peel": "🍌",
+  "coffee-grounds": "☕",
+  "tea-bag": "🫖",
+  "cut-flowers": "💐",
+  "bread-roll": "🥖",
+  "broken-ceramic-mug": "☕",
+  "vacuum-dust": "🧹",
+  "used-tissue": "🤧",
+  "cold-ash": "🔥",
+  "glass-bottle-deposit": "🍾",
+  battery: "🔋",
+  "light-bulb-led": "💡",
+  "paint-can-with-residue": "🎨",
+  "electronics-cable": "🔌"
 };
 
 function escapeHtml(value) {
@@ -38,7 +57,7 @@ function getOutcomeBadgeClass(outcomeKey) {
 }
 
 function getItemEmoji(item) {
-  return ITEM_EMOJI_BY_OUTCOME[item.primary_outcome] || "🗑️";
+  return ITEM_EMOJI_BY_SLUG[item.slug] || "🗑️";
 }
 
 function updateSummary(state) {

--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -1,4 +1,4 @@
-const ROUND_SIZE = 5;
+const ROUND_SIZE = 10;
 const ANSWER_KEYS = ["paper", "packaging", "bio", "residual"];
 
 function createInitialProgress(progress) {

--- a/index.html
+++ b/index.html
@@ -34,11 +34,11 @@
         <section id="quiz-preview" class="quiz-preview surface-panel surface-panel--quiz">
           <div class="quiz-progress-shell">
             <div class="progress-meta progress-meta--quiz">
-              <span id="question-counter">1 / 5</span>
+              <span id="question-counter">Question 1 of 10</span>
               <span id="round-label">Warm-up round</span>
             </div>
             <div class="progress-track" aria-hidden="true">
-              <div id="progress-fill" class="progress-fill" style="width: 20%"></div>
+              <div id="progress-fill" class="progress-fill" style="width: 10%"></div>
             </div>
           </div>
 
@@ -49,7 +49,9 @@
 
           <div class="item-stage item-stage--hero">
             <div class="item-card item-card--hero">
-              <div id="item-emoji" class="item-emoji" aria-hidden="true">🗑️</div>
+              <div id="item-visual" class="item-visual" aria-hidden="true">
+                <span id="item-emoji" class="item-emoji">🗑️</span>
+              </div>
               <p id="item-caption" class="item-caption">Loading quiz item…</p>
               <p id="item-hint" class="item-hint">Think like a Berlin local.</p>
             </div>

--- a/tests/quiz-logic/quiz.test.js
+++ b/tests/quiz-logic/quiz.test.js
@@ -3,33 +3,30 @@ import { advanceQuiz, createQuizState, submitAnswer } from "../../assets/js/quiz
 
 const items = [
   { slug: "clean-cardboard-box", active: true, primary_outcome: "paper" },
+  { slug: "newspaper", active: true, primary_outcome: "paper" },
+  { slug: "paper-egg-carton", active: true, primary_outcome: "paper" },
   { slug: "yogurt-cup", active: true, primary_outcome: "packaging" },
+  { slug: "plastic-bottle-no-deposit", active: true, primary_outcome: "packaging" },
+  { slug: "tin-can", active: true, primary_outcome: "packaging" },
   { slug: "banana-peel", active: true, primary_outcome: "bio" },
+  { slug: "coffee-grounds", active: true, primary_outcome: "bio" },
   { slug: "used-tissue", active: true, primary_outcome: "residual" },
-  { slug: "newspaper", active: true, primary_outcome: "paper" }
+  { slug: "vacuum-dust", active: true, primary_outcome: "residual" },
+  { slug: "cold-ash", active: true, primary_outcome: "residual" }
 ];
 
 const initial = createQuizState(items, { roundsCompleted: 0, correctAnswers: 0, questionsAnswered: 0 });
-assert.equal(initial.items.length, 5);
+assert.equal(initial.items.length, 10);
 assert.equal(initial.status, "ready");
 
-submitAnswer(initial, "paper");
-assert.equal(initial.answered, true);
-assert.equal(initial.roundCorrect, 1);
-assert.equal(initial.progress.correctAnswers, 1);
-
-advanceQuiz(initial);
-assert.equal(initial.currentIndex, 1);
-assert.equal(initial.answered, false);
-
-submitAnswer(initial, "paper");
-advanceQuiz(initial);
-submitAnswer(initial, "bio");
-advanceQuiz(initial);
-submitAnswer(initial, "residual");
-advanceQuiz(initial);
-submitAnswer(initial, "paper");
-advanceQuiz(initial);
+for (const item of initial.items) {
+  submitAnswer(initial, item.primary_outcome);
+  assert.equal(initial.answered, true);
+  advanceQuiz(initial);
+}
 
 assert.equal(initial.status, "complete");
 assert.equal(initial.progress.roundsCompleted, 1);
+assert.equal(initial.roundCorrect, 10);
+assert.equal(initial.progress.correctAnswers, 10);
+assert.equal(initial.progress.questionsAnswered, 10);


### PR DESCRIPTION
## What
- replace generic outcome-based quiz emojis with item-specific visuals
- increase the default quiz round length from 5 to 10 questions
- update the homepage quiz shell defaults and test expectations for the longer round

## Why
The deployed page still felt placeholder-like because different items reused the same coarse emoji mapping. The round also ended too quickly at only 5 questions, which made the quiz feel shallow.

## How
- changed the quiz item visual mapping to use item-specific slug-based visuals in `assets/js/app.js`
- increased `ROUND_SIZE` to 10 in `assets/js/quiz.js`
- updated `index.html` defaults to match the longer round
- refreshed the quiz logic test to validate a 10-question round

Closes #19

## Validation
- `node --check assets/js/app.js`
- `node --check assets/js/quiz.js`
- `node --check tests/quiz-logic/quiz.test.js`
- `node tests/quiz-logic/quiz.test.js`