### PR TITLE
✨ add bilingual disposal labels

### DIFF
--- a/assets/data/disposal-items.json
+++ b/assets/data/disposal-items.json
@@ -4,30 +4,35 @@
     {
       "key": "paper",
       "label_en": "Paper",
+      "label_de": "Blaue Tonne",
       "short_description_en": "Clean paper and cardboard recycling.",
       "special_handling": false
     },
     {
       "key": "packaging",
       "label_en": "Packaging",
+      "label_de": "Wertstofftonne",
       "short_description_en": "Light packaging such as plastic, metal, and composites.",
       "special_handling": false
     },
     {
       "key": "bio",
       "label_en": "Bio",
+      "label_de": "Biomüll",
       "short_description_en": "Food scraps and compostable organic waste where accepted.",
       "special_handling": false
     },
     {
       "key": "residual",
       "label_en": "Residual",
+      "label_de": "Restmüll",
       "short_description_en": "General household waste that does not fit the recycling streams.",
       "special_handling": false
     },
     {
       "key": "special",
       "label_en": "Special disposal",
+      "label_de": "Sondermüll / Sammelstelle",
       "short_description_en": "Items that require collection points, return systems, or hazardous waste disposal.",
       "special_handling": true
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,33 +16,6 @@ const ANSWER_TILE_CLASS = {
   residual: "answer-tile--residual"
 };
 
-const ITEM_EMOJI_BY_SLUG = {
-  "greasy-pizza-box": "🍕",
-  "clean-cardboard-box": "📦",
-  newspaper: "📰",
-  "paper-egg-carton": "🥚",
-  "receipt-paper": "🧾",
-  "yogurt-cup": "🥛",
-  "plastic-bottle-no-deposit": "🧴",
-  "tin-can": "🥫",
-  "aluminum-foil-clean": "✨",
-  "drink-carton": "🧃",
-  "banana-peel": "🍌",
-  "coffee-grounds": "☕",
-  "tea-bag": "🫖",
-  "cut-flowers": "💐",
-  "bread-roll": "🥖",
-  "broken-ceramic-mug": "☕",
-  "vacuum-dust": "🧹",
-  "used-tissue": "🤧",
-  "cold-ash": "🔥",
-  "glass-bottle-deposit": "🍾",
-  battery: "🔋",
-  "light-bulb-led": "💡",
-  "paint-can-with-residue": "🎨",
-  "electronics-cable": "🔌"
-};
-
 function escapeHtml(value) {
   return String(value)
     .replaceAll("&", "&amp;")
@@ -56,8 +29,9 @@ function getOutcomeBadgeClass(outcomeKey) {
   return ANSWER_TILE_CLASS[outcomeKey]?.replace("answer-tile", "badge") || "badge--residual";
 }
 
-function getItemEmoji(item) {
-  return ITEM_EMOJI_BY_SLUG[item.slug] || "🗑️";
+function formatOutcomeLabel(outcome) {
+  if (!outcome) return "Unknown";
+  return outcome.label_de ? `${outcome.label_en} (${outcome.label_de})` : outcome.label_en;
 }
 
 function updateSummary(state) {
@@ -70,7 +44,6 @@ function renderCompleteState(state) {
   document.querySelector("#round-label").textContent = "Round complete";
   document.querySelector("#progress-fill").style.width = "100%";
   document.querySelector("#quiz-title").textContent = `Round complete — ${state.roundCorrect}/${state.items.length}`;
-  document.querySelector("#item-emoji").textContent = "🏁";
   document.querySelector("#item-caption").textContent = "Nice. You can replay by refreshing or move on to the next issue.";
   document.querySelector("#item-hint").textContent = "You just completed the current learning round.";
   document.querySelector("#answer-grid").innerHTML = '<a class="button button--primary" href="#quiz-preview">Great job</a>';
@@ -95,7 +68,6 @@ function renderQuestion(state, catalog) {
   document.querySelector("#round-label").textContent = state.answered ? "Answer reviewed" : `${Math.round(getProgressPercent(state))}% complete`;
   document.querySelector("#progress-fill").style.width = `${getProgressPercent(state)}%`;
   document.querySelector("#quiz-title").textContent = item.question_prompt_en;
-  document.querySelector("#item-emoji").textContent = getItemEmoji(item);
   document.querySelector("#item-caption").textContent = item.name_en;
   document.querySelector("#item-hint").textContent = item.source_note || "Choose the best Berlin disposal path.";
   updateSummary(state);
@@ -109,7 +81,7 @@ function renderQuestion(state, catalog) {
       .map(
         (option) => `
           <button class="answer-tile ${ANSWER_TILE_CLASS[option.key] ?? ""}" type="button" data-outcome-key="${option.key}">
-            <span class="answer-tile__label">${escapeHtml(option.label_en)}</span>
+            <span class="answer-tile__label">${escapeHtml(formatOutcomeLabel(option))}</span>
             <span class="answer-tile__hint">${escapeHtml(option.short_description_en)}</span>
           </button>
         `
@@ -144,7 +116,7 @@ function renderQuestion(state, catalog) {
   feedbackPanel.innerHTML = `
     <strong>${correct ? "Correct!" : "Not quite"}</strong>
     <p>${escapeHtml(item.explanation_en)}</p>
-    <p><span class="badge ${getOutcomeBadgeClass(item.primary_outcome)}">${escapeHtml(outcome?.label_en || item.primary_outcome)}</span></p>
+    <p><span class="badge ${getOutcomeBadgeClass(item.primary_outcome)}">${escapeHtml(formatOutcomeLabel(outcome))}</span></p>
   `;
 }
 

--- a/assets/js/cards.js
+++ b/assets/js/cards.js
@@ -17,6 +17,11 @@ function escapeHtml(value) {
     .replaceAll("'", "&#39;");
 }
 
+function formatOutcomeLabel(outcome) {
+  if (!outcome) return "Unknown";
+  return outcome.label_de ? `${outcome.label_en} (${outcome.label_de})` : outcome.label_en;
+}
+
 function renderCardsIndex(catalog) {
   const container = document.querySelector("#cards-grid");
   if (!container) return;
@@ -30,7 +35,7 @@ function renderCardsIndex(catalog) {
 
       return `
         <article class="mini-card surface-panel">
-          <span class="badge ${badgeClass}">${escapeHtml(outcome?.label_en || "Unknown")}</span>
+          <span class="badge ${badgeClass}">${escapeHtml(formatOutcomeLabel(outcome))}</span>
           <h2>${escapeHtml(item.name_en)}</h2>
           <p>${escapeHtml(item.explanation_en)}</p>
           <a class="button button--tertiary" href="item.html?slug=${encodeURIComponent(item.slug)}">Open card</a>
@@ -65,7 +70,7 @@ function renderCardDetail(catalog) {
     : "";
 
   container.innerHTML = `
-    <span class="badge ${badgeClass}">${escapeHtml(outcome?.label_en || "Unknown")}</span>
+    <span class="badge ${badgeClass}">${escapeHtml(formatOutcomeLabel(outcome))}</span>
     <h1>${escapeHtml(item.name_en)}</h1>
     <p class="lead">${escapeHtml(item.explanation_en)}</p>
     <div class="detail-note surface-panel surface-panel--nested">


### PR DESCRIPTION
## What
- add German disposal terms to the outcome catalog
- render bilingual English + German disposal labels in quiz and cards UI
- keep the app English-first while surfacing the German names users will actually see in Berlin

## Why
Issue #24 is about helping expats connect the English explanation with the local German bin/disposal names used in buildings and recycling systems.

## How
- added `label_de` to each outcome in `assets/data/disposal-items.json`
- added shared bilingual label formatting in the quiz and cards UI layers
- updated answer tiles, badges, and feedback labels to show English + German together

Closes #24

## Validation
- Python JSON validation for outcome `label_de` fields
- `node --check assets/js/app.js`
- `node --check assets/js/cards.js`
- `node --check assets/js/data-loader.js`